### PR TITLE
let /system be ro as much as possible

### DIFF
--- a/chroot_scripts/bootpwn
+++ b/chroot_scripts/bootpwn
@@ -4,13 +4,6 @@
 # Export chroot directory into variable
 export NEW_ROOT=/data/local/kali
 
-echo "[+] Mounting filesystems..."
-
-# Remount system partition with rw flag set
-mount -o remount,rw -t yaffs /dev/block/mtdblock3 /system
-
-echo "[+] Filesystems mounted."
-
 sysctl -w net.ipv4.ip_forward=1 &> /dev/null
 
 # Setup environment variables for shell environment

--- a/chroot_scripts/chrootboot
+++ b/chroot_scripts/chrootboot
@@ -16,9 +16,6 @@ mount -o loop -t ext4 $SOURCE_IMG $NEW_ROOT
 /system/xbin/mount --rbind /proc $NEW_ROOT/proc
 /system/xbin/mount --rbind /sys $NEW_ROOT/sys
 
-# Remount system partition with rw flag set
-mount -o remount,rw -t yaffs /dev/block/mtdblock3 /system
-
 # Mount Android filesystems for chroot environment
 /system/xbin/mount --rbind /sdcard $NEW_ROOT/sdcard
 /system/xbin/mount --rbind /system $NEW_ROOT/system

--- a/scripts/updatepwnpad.sh
+++ b/scripts/updatepwnpad.sh
@@ -30,16 +30,7 @@ f_one_or_two(){
 f_confirm_and_do_update(){
   if [ $(f_one_or_two) -eq 1 ]; then
     echo "Starting update..."
-    # If /system is mounted ro then mount rw for update then mount back
-    # Avoid having /system mounted rw
-    if [ ! -w /system ]; then
-      local remount=yes
-      mount -o rw,remount /system
-  fi
     /opt/pwnix/chef/update.sh
-    if [ "remount" = "yes" ]; then
-      mount -o ro,remount /system
-    fi
     echo
     echo "[!] Congratulations, this device has been updated!"
     echo "The current version is:"


### PR DESCRIPTION
Android expects /system to be ro, and any mistakes could easily destroy
android, so let's not mess with it and leave it ro except during updates.

This PR depends on https://github.com/pwnieexpress/pwnix_chef/pull/158 otherwise updates *WILL* fail on the mobile line.