### PR TITLE
handles cases where busybox does not have proper symlinks

### DIFF
--- a/chroot_scripts/bootpwn
+++ b/chroot_scripts/bootpwn
@@ -22,12 +22,12 @@ unset LD_PRELOAD
 
 echo "[!] Welcome to the Pwn zone. Get your game face on."
 
-/system/xbin/stty columns 85
-/system/xbin/stty rows 46
+/system/xbin/busybox stty columns 85
+/system/xbin/busybox stty rows 46
 
 # Copy mounts so chroot can see what is mounted
 # Can then mount USB OTG flash drive to copy files to/from chroot environment
-/system/xbin/cp /proc/mounts $NEW_ROOT/etc/mtab
+/system/xbin/busybox cp /proc/mounts $NEW_ROOT/etc/mtab
 
 # Drop user to shell
-/system/xbin/chroot $NEW_ROOT /bin/bash
+/system/xbin/busybox chroot $NEW_ROOT /bin/bash

--- a/chroot_scripts/chrootboot
+++ b/chroot_scripts/chrootboot
@@ -12,16 +12,16 @@ export NEW_ROOT=/data/local/kali
 mount -o loop -t ext4 $SOURCE_IMG $NEW_ROOT
 
 # Mount other filesystems for chroot environment
-/system/xbin/mount --rbind /dev $NEW_ROOT/dev
-/system/xbin/mount --rbind /proc $NEW_ROOT/proc
-/system/xbin/mount --rbind /sys $NEW_ROOT/sys
+/system/xbin/busybox mount --rbind /dev $NEW_ROOT/dev
+/system/xbin/busybox mount --rbind /proc $NEW_ROOT/proc
+/system/xbin/busybox mount --rbind /sys $NEW_ROOT/sys
 
 # Remount system partition with rw flag set
 mount -o remount,rw -t yaffs /dev/block/mtdblock3 /system
 
 # Mount Android filesystems for chroot environment
-/system/xbin/mount --rbind /sdcard $NEW_ROOT/sdcard
-/system/xbin/mount --rbind /system $NEW_ROOT/system
+/system/xbin/busybox mount --rbind /sdcard $NEW_ROOT/sdcard
+/system/xbin/busybox mount --rbind /system $NEW_ROOT/system
 
 sysctl -w net.ipv4.ip_forward=1 &> /dev/null
 
@@ -35,16 +35,16 @@ export TERM=xterm-color
 unset LD_PRELOAD
 
 # Copy mounts so chroot can see what is mounted
-/system/xbin/chroot $NEW_ROOT /bin/cp /proc/mounts /etc/mtab
+/system/xbin/busybox chroot $NEW_ROOT /bin/cp /proc/mounts /etc/mtab
 
 # Start services in chroot environment
-/system/xbin/chroot $NEW_ROOT /etc/init.d/cron start
-/system/xbin/chroot $NEW_ROOT /etc/init.d/hermes start
-/system/xbin/chroot $NEW_ROOT /etc/init.d/insight_api start
+/system/xbin/busybox chroot $NEW_ROOT /etc/init.d/cron start
+/system/xbin/busybox chroot $NEW_ROOT /etc/init.d/hermes start
+/system/xbin/busybox chroot $NEW_ROOT /etc/init.d/insight_api start
 
 # If first_boot.sh is in chroot root filesystem (/data/local/kali); then
 # run it to generate SSH keys, etc.
 # Run this last in /system/bin/chrootboot
 if [ -x $NEW_ROOT/first_boot.sh ]; then
-  /system/xbin/chroot $NEW_ROOT /first_boot.sh
+  /system/xbin/busybox chroot $NEW_ROOT /first_boot.sh
 fi


### PR DESCRIPTION
we have been using the symlinks to various busybox functionality rather than calling busybox directly.  This works great if the symlink is in place, however, if for some reason the symlink is not in place, it will fail horribly.  This change simply ALWAYS calls busybox and asks for the requested function.