### PR TITLE
fix mon mode interface mac randomization

### DIFF
--- a/scripts/evilap.sh
+++ b/scripts/evilap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Date: May 2014
+# Date: May 2015
 # Desc: EvilAP script to forcefully connect wireless clients
 # Authors: Awk, Sedd, Pasties, t1mz0r
 # Company: Pwnie Express
@@ -117,20 +117,22 @@ f_beacon_rate(){
 
 f_preplaunch(){
   #Change the hostname and mac address randomly
-
   echo "[+] Rolling MAC address and hostname randomly"
   echo
 
   ifconfig wlan1 down
-  macchanger -r wlan1
 
   hn=`ifconfig wlan1 |grep HWaddr |awk '{print$5}' |awk -F":" '{print$1$2$3$4$5$6}'`
   hostname $hn
   echo "[+] New hostname set: $hn"
 
   sleep 2
-  #Put wlan1 into monitor mode - wlan1mon created
+  #Put wlan1 into monitor mode and randomize mac - wlan1mon created
   airmon-ng start wlan1
+  ifconfig wlan1mon down
+  macchanger -r wlan1mon
+  ifconfig wlan1mon up
+
   mkdir /dev/net/ &> /dev/null
   ln -s /dev/tun /dev/net/tun &> /dev/null
 }


### PR DESCRIPTION
Turns out the interfaces brought up by evilap (wlan1mon and at0) are not properly being randomized. Right now, wlan1 is being randomized before being put into mon mode, which doesn't actually work. This fix puts wlan1 into mon mode, brings the resultant wlan1mon interface down, randomizes its mac, then brings it back up.