### PR TITLE
ssh connections are killed by SELinux in enforcing mode

### DIFF
--- a/chroot_scripts/chrootboot
+++ b/chroot_scripts/chrootboot
@@ -2,7 +2,7 @@
 # Start chroot environment and services at system startup
 
 # Set SELinux to permissive
-# su 0 setenforce 0
+su 0 setenforce 0
 
 # Use the fourth loopback device to leave the first couple open
 export LOOP_BACK=/dev/block/loop4


### PR DESCRIPTION
ssh_selinux_getctxbyname: Failed to get default SELinux security context
for pwnie (in enforcing mode)


This is OPTION ONE of TWO.  One of these two PR's should be merged but probably not both.

This option disables SELinux at boot, and leaves it that way.