### PR TITLE
sshd is killed by selinux

### DIFF
--- a/scripts/ssh_on_off.sh
+++ b/scripts/ssh_on_off.sh
@@ -4,6 +4,7 @@
 f_start_ssh(){
   echo "[+] Starting SSH server..."
   service ssh start
+  /system/bin/setenforce 0
   echo "[!] Done"
   echo
 }


### PR DESCRIPTION
ssh_selinux_getctxbyname: Failed to get default SELinux security context
for pwnie (in enforcing mode)

This is OPTION TWO of TWO.  One of these two PR's should be merged but probably not both.

this option disables SELinux when starting sshd, and leaves it that way.