### PR TITLE
Script cleanup and refinement

### DIFF
--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -12,7 +12,12 @@ set -e
 set -u
 
 check_dependencies() {
-  dependencies=(adb fastboot)
+  # Have dependency checking to ensure users know which packages to install
+  # on a new system
+  dependencies=(
+    adb
+    fastboot
+  )
   for command in "${dependencies[@]}"; do
     if ! [ -x "$(command -v "${command}")" ]; then
       echo "Command '${command}' not found. Please have android-tools-adb and android-tools-fastboot packages installed." >&2
@@ -21,12 +26,11 @@ check_dependencies() {
   done
 }
 
-f_pause(){
+f_pause() {
   read -p "$*"
 }
 
-f_run(){
-
+f_run() {
   # Splash
   clear
   echo " "
@@ -87,7 +91,6 @@ f_run(){
 }
 
 f_getserial() {
-
   # Count devices
   device_count="$(fastboot devices | wc -l)"
 
@@ -114,7 +117,6 @@ f_getserial() {
 }
 
 f_unlock() {
-
   # Unlock bootloader
   echo
   echo "[+] Unlock the device"
@@ -159,7 +161,6 @@ f_unlock() {
 }
 
 f_setup() {
-
   # Boot into recovery
   echo
   echo "[+] Boot into recovery"

--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -51,12 +51,12 @@ f_run(){
   echo "                                                                                     "
   echo " 	Boot device into fastboot mode and attach to host machine.                   "
   echo
-  f_pause ' Press [ENTER] to continue, CTRL+C to abort. '
+  f_pause " Press [ENTER] to continue, CTRL+C to abort. "
 
   # Check for root
-  if [[ $EUID -ne 0 ]]; then
+  if [[ "${EUID}" -ne "0" ]]; then
     echo    
-    echo ' [!] This tool must be run as root [!]'
+    echo " [!] This tool must be run as root [!]"
     echo    
     exit 1
   fi
@@ -76,22 +76,22 @@ f_run(){
 f_getserial() {
 
   # Count devices
-  device_count=`fastboot devices |wc -l`
+  device_count="$(fastboot devices | wc -l)"
 
   # Store serials
-  j=0
+  j="0"
   while read line
   do
-    serial_array[$j]="$line"
+    serial_array["${j}"]="${line}"
     (( j++ ))
-  done < <(fastboot devices |cut -c 1-12)
+  done < <(fastboot devices | cut -c 1-12)
 
   # Print devices
-  if (( $device_count > 1 ))
+  if (( "${device_count}" > 1 ))
   then
-    echo 'There are' $device_count 'devices connected: '
+    echo "There are ${device_count} devices connected: "
   else
-    echo 'There is 1 device connected: '
+    echo "There is 1 device connected: "
   fi
   fastboot devices
 }
@@ -100,18 +100,18 @@ f_unlock() {
 
   # Unlock bootloader
   echo
-  echo '[+] Unlock the device'
+  echo "[+] Unlock the device"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    fastboot oem unlock -s ${serial_array[$k]} &
+    fastboot oem unlock -s "${serial_array["${k}"]}" &
     (( k++ ))
   done
   wait
 
   # Wait for unlock
-  devices=`fastboot devices |wc -l`
-  while (( $devices < 1 ))
+  devices="$(fastboot devices | wc -l)"
+  while (( "${devices}" < 1 ))
   do
     sleep 1
   done
@@ -119,11 +119,11 @@ f_unlock() {
 
   # Flash recovery
   echo
-  echo '[+] Flash recovery'
+  echo "[+] Flash recovery"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    fastboot flash recovery twrp-3.0.2-0-flounder.img -s ${serial_array[$k]} &
+    fastboot flash recovery twrp-3.0.2-0-flounder.img -s "${serial_array["${k}"]}" &
     sleep 1
     (( k++ ))
   done
@@ -131,11 +131,11 @@ f_unlock() {
 
   # Format system
   echo
-  echo '[+] Erase and format system'
+  echo "[+] Erase and format system"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    fastboot format system -s ${serial_array[$k]} &
+    fastboot format system -s "${serial_array["${k}"]}" &
     (( k++ ))
   done
   wait
@@ -145,59 +145,59 @@ f_setup() {
 
   # Boot into recovery
   echo
-  echo '[+] Boot into recovery'
+  echo "[+] Boot into recovery"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    fastboot boot twrp-3.0.2-0-flounder.img -s ${serial_array[$k]} &
+    fastboot boot twrp-3.0.2-0-flounder.img -s "${serial_array["${k}"]}" &
     sleep 1
     (( k++ ))
   done
   wait
 
   echo
-  f_pause '[!] Swipe to allow modifications. Press [ENTER] to continue.'
+  f_pause "[!] Swipe to allow modifications. Press [ENTER] to continue."
 
   # Remove old chroot files
   echo
-  echo '[+] Remove old chroot files'
+  echo "[+] Remove old chroot files"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} shell rm -rf /sdcard/Android/data/com.pwnieexpress.android.pxinstaller/files/* &
+    adb -s "${serial_array[${k}]}" shell rm -rf /sdcard/Android/data/com.pwnieexpress.android.pxinstaller/files/* &
     (( k++ ))
   done
   wait
 
   # Format userdata
   echo
-  echo '[+] Erase and format userdata'
+  echo "[+] Erase and format userdata"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} shell twrp wipe data &
+    adb -s "${serial_array["${k}"]}" shell twrp wipe data &
     (( k++ ))
   done
   wait
 
   # Format cache
   echo
-  echo '[+] Erase and format cache'
+  echo "[+] Erase and format cache"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} shell twrp wipe cache &
+    adb -s "${serial_array["${k}"]}" shell twrp wipe cache &
     (( k++ ))
   done
   wait
 
   # Format dalvik-cache
   echo
-  echo '[+] Erase and format dalvik-cache'
+  echo "[+] Erase and format dalvik-cache"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} shell twrp wipe dalvik &
+    adb -s "${serial_array["${k}"]}" shell twrp wipe dalvik &
     (( k++ ))
   done
   wait
@@ -207,11 +207,11 @@ f_flash() {
 
   # Push rom zip
   echo
-  echo '[+] Push ROM zip'
+  echo "[+] Push ROM zip"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} push aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip /sdcard/ &
+    adb -s "${serial_array[$k]}" push aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip /sdcard/ &
     sleep 1
     (( k++ ))
   done
@@ -219,11 +219,11 @@ f_flash() {
 
   # Flash rom zip
   echo
-  echo '[+] Flash ROM zip'
+  echo "[+] Flash ROM zip"
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} shell twrp install /sdcard/aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip &
+    adb -s "${serial_array[${k}]}" shell twrp install /sdcard/aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip &
     sleep 1
     (( k++ ))
   done
@@ -231,12 +231,12 @@ f_flash() {
  
   # Reboot
   echo
-  echo '[+] Reboot'
+  echo "[+] Reboot"
   echo 
   k=0
-  while (( $k < $device_count ))
+  while (( "${k}" < "${device_count}" ))
   do
-    adb -s ${serial_array[$k]} reboot &
+    adb -s "${serial_array["${k}"]}" reboot &
     (( k++ ))
   done
   wait

--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -6,6 +6,11 @@
 # Company: Pwnie Express
 # Contact: josefelipe@pwnieexpress.com
 
+# Increase strictness by making script exit to catch potential bugs caused by
+# failed commands or unset variables
+set -e
+set -u
+
 f_pause(){
   read -p "$*"
 }

--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -90,11 +90,15 @@ f_getserial() {
   done < <(fastboot devices | cut -c 1-12)
 
   # Print devices
-  if (( "${device_count}" > 1 ))
+  if [[ "${device_count}" -gt "1" ]]
   then
     echo "There are ${device_count} devices connected: "
-  else
+  elif [[ "${device_count}" -eq "1" ]]
+  then
     echo "There is 1 device connected: "
+  else
+    echo "There are no devices connected. Exiting now."
+    exit 1
   fi
   fastboot devices
 }
@@ -105,7 +109,7 @@ f_unlock() {
   echo
   echo "[+] Unlock the device"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     fastboot oem unlock -s "${serial_array["${k}"]}" &
     (( k++ ))
@@ -114,7 +118,7 @@ f_unlock() {
 
   # Wait for unlock
   devices="$(fastboot devices | wc -l)"
-  while (( "${devices}" < 1 ))
+  while (( "${devices}" -lt 1 ))
   do
     sleep 1
   done
@@ -124,7 +128,7 @@ f_unlock() {
   echo
   echo "[+] Flash recovery"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     fastboot flash recovery twrp-3.0.2-0-flounder.img -s "${serial_array["${k}"]}" &
     sleep 1
@@ -136,7 +140,7 @@ f_unlock() {
   echo
   echo "[+] Erase and format system"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     fastboot format system -s "${serial_array["${k}"]}" &
     (( k++ ))
@@ -150,7 +154,7 @@ f_setup() {
   echo
   echo "[+] Boot into recovery"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     fastboot boot twrp-3.0.2-0-flounder.img -s "${serial_array["${k}"]}" &
     sleep 1
@@ -165,7 +169,7 @@ f_setup() {
   echo
   echo "[+] Remove old chroot files"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array[${k}]}" shell rm -rf /sdcard/Android/data/com.pwnieexpress.android.pxinstaller/files/* &
     (( k++ ))
@@ -176,7 +180,7 @@ f_setup() {
   echo
   echo "[+] Erase and format userdata"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array["${k}"]}" shell twrp wipe data &
     (( k++ ))
@@ -187,7 +191,7 @@ f_setup() {
   echo
   echo "[+] Erase and format cache"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array["${k}"]}" shell twrp wipe cache &
     (( k++ ))
@@ -198,7 +202,7 @@ f_setup() {
   echo
   echo "[+] Erase and format dalvik-cache"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array["${k}"]}" shell twrp wipe dalvik &
     (( k++ ))
@@ -212,7 +216,7 @@ f_flash() {
   echo
   echo "[+] Push ROM zip"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array[$k]}" push aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip /sdcard/ &
     sleep 1
@@ -224,7 +228,7 @@ f_flash() {
   echo
   echo "[+] Flash ROM zip"
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array[${k}]}" shell twrp install /sdcard/aopp-0.1-20160523-UNOFFICIAL-flounder_lte.zip &
     sleep 1
@@ -237,7 +241,7 @@ f_flash() {
   echo "[+] Reboot"
   echo 
   k=0
-  while (( "${k}" < "${device_count}" ))
+  while (( "${k}" -lt "${device_count}" ))
   do
     adb -s "${serial_array["${k}"]}" reboot &
     (( k++ ))

--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -61,8 +61,11 @@ f_run(){
     exit 1
   fi
 
-  # Kill running server
-  killall adb &> /dev/null
+  # Kill server if one is already running
+  if [[ -n "$(pgrep adb)" ]]; then
+    echo "Killing server"
+    killall adb &> /dev/null
+  fi
 
   # Start server
   echo

--- a/manufacturing_scripts/aopp-flash-flounder.sh
+++ b/manufacturing_scripts/aopp-flash-flounder.sh
@@ -11,6 +11,16 @@
 set -e
 set -u
 
+check_dependencies() {
+  dependencies=(adb fastboot)
+  for command in "${dependencies[@]}"; do
+    if ! [ -x "$(command -v "${command}")" ]; then
+      echo "Command '${command}' not found. Please have android-tools-adb and android-tools-fastboot packages installed." >&2
+      exit 1
+    fi
+  done
+}
+
 f_pause(){
   read -p "$*"
 }
@@ -249,6 +259,7 @@ f_flash() {
   wait
 }
 
+check_dependencies
 f_run
 f_unlock
 f_setup


### PR DESCRIPTION
The gist of this pull request:

- Use higher strictness levels to catch bugs and program defensively
- Add dependency checking for adb and fastboot so the script only runs if they're installed
- Clean up some of the code formatting conventions

Bash by default is very lenient about catching errors, so a script should be set to halt for reasons including unset variables or failed commands. While a little extra work is required in making a script more defensive, [it could save some headaches later](https://github.com/ValveSoftware/steam-for-linux/issues/3671) when trying to catch a bug that slips by in testing but comes up in production.

Dependency checking is also used, because a new user might want to use this utility but might not know which packages need to be installed aside from the ones that ship with their distribution.

Code formatting is also cleaned up a bit, for instance $VAR is changed to "${VAR}". In Bash, everything is a string, and certain statements might evaluate differently because there was a space in a variable that wasn't escaped

That said, I haven't been able to run the entirety of this script since I have neither the .img files nor the hardware to flash them on, so there's likely a regression introduced due to reliance on certain behaviour that would've been caught as a bug. Please let me know if there are any bugs you've found and I can try to fix them.