### PR TITLE
start ssh service as pwnie user

### DIFF
--- a/scripts/ssh_on_off.sh
+++ b/scripts/ssh_on_off.sh
@@ -45,7 +45,7 @@ selinuxfs() {
 
 f_start_ssh(){
   printf "[+] Starting SSH server...\n"
-  service ssh start
+  sudo su - pwnie service ssh start
   selinuxfs unlock
   /system/bin/setenforce 0 > /dev/null 2>&1
   selinuxfs lock


### PR DESCRIPTION
This is not **the fix** but the workaround all devices need so they at least have ssh access via the pwnie user.