### PR TITLE
s/-a/-R

### DIFF
--- a/scripts/usb_copy.sh
+++ b/scripts/usb_copy.sh
@@ -39,7 +39,7 @@ f_mount_cp(){
     mount /dev/block/sda1 /usb-otg/
     printf "\n[!] ..Done\n\n"
     printf "[+] Copying captures directory...\n\n"
-    cp -a /opt/pwnix/captures/ /usb-otg/
+    cp -R /opt/pwnix/captures/ /usb-otg/
     printf "\n[!] ..Done\n\n"
     f_umount
   else


### PR DESCRIPTION
The vast majority of users will by copying onto a fat32 flash drive so preserving permissions and refusing to dereference  symlinks is silly and provides a stack of errors that are meaningless