### PR TITLE
Handle sighup

### DIFF
--- a/scripts/airodump.sh
+++ b/scripts/airodump.sh
@@ -97,7 +97,6 @@ f_gps_toggle(){
   esac
 }
 
-# Clean up without asking when the user hangs up (closes window)
 f_hangup(){
   adpid=`pgrep airodump-ng|head -n 1`
   kill 2 ${adpid}

--- a/scripts/airodump.sh
+++ b/scripts/airodump.sh
@@ -101,12 +101,6 @@ f_gps_toggle(){
 f_hangup(){
   adpid=`pgrep airodump-ng|head -n 1`
   kill 2 ${adpid}
-
-  # Stop monitor interface without asking
-  airmon-ng stop wlan1mon &> /dev/null
-
-  # Kill gpsd without asking
-  killall -9 gpsd &> /dev/null 
 }
 
 f_cleanup(){

--- a/scripts/airodump.sh
+++ b/scripts/airodump.sh
@@ -17,7 +17,7 @@ f_run(){
   #we have a monitor interface now, so set traps to cleanup
   trap f_cleanup INT
   trap f_cleanup KILL
-  trap f_cleanup SIGHUP
+  trap f_hangup SIGHUP
 
   STD_OPTS="-C0 --manufacturer"
   if [ $opt_log -eq 1 ]; then
@@ -95,6 +95,18 @@ f_gps_toggle(){
       ;;
     *)f_gps_toggle ;;
   esac
+}
+
+# Clean up without asking when the user hangs up (closes window)
+f_hangup(){
+  adpid=`pgrep airodump-ng|head -n 1`
+  kill 2 ${adpid}
+
+  # Stop monitor interface without asking
+  airmon-ng stop wlan1mon &> /dev/null
+
+  # Kill gpsd without asking
+  killall -9 gpsd &> /dev/null 
 }
 
 f_cleanup(){

--- a/scripts/airodump.sh
+++ b/scripts/airodump.sh
@@ -17,6 +17,7 @@ f_run(){
   #we have a monitor interface now, so set traps to cleanup
   trap f_cleanup INT
   trap f_cleanup KILL
+  trap f_cleanup SIGHUP
 
   STD_OPTS="-C0 --manufacturer"
   if [ $opt_log -eq 1 ]; then

--- a/scripts/blue_hydra.sh
+++ b/scripts/blue_hydra.sh
@@ -70,6 +70,6 @@ if loud_one=1 f_validate_one hci0; then
   trap f_endsummary INT
   trap f_endsummary KILL
   trap f_intbh SIGHUP
-  ./bin/blue_hydra 
+  ./bin/blue_hydra
   f_endsummary
 fi

--- a/scripts/blue_hydra.sh
+++ b/scripts/blue_hydra.sh
@@ -8,7 +8,6 @@ bluetooth=1
 . /opt/pwnix/pwnpad-scripts/px_functions.sh
 
 f_intbh(){
-  # bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
    BH_PID=`pgrep -f /bin/blue_hydra`
    kill 2 ${BH_PID}
    printf "\nBlue_Hydra process killed...\n"
@@ -17,7 +16,6 @@ f_intbh(){
 
 f_cleanup(){
   printf "\nStopping Services...\n"
-  service dbus stop #needed?
   service bluetooth stop
 }
 

--- a/scripts/blue_hydra.sh
+++ b/scripts/blue_hydra.sh
@@ -8,8 +8,9 @@ bluetooth=1
 . /opt/pwnix/pwnpad-scripts/px_functions.sh
 
 f_intbh(){
-   bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
-   `kill 2 ${bhPID}`
+  # bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
+   BH_PID=`pgrep -f /bin/blue_hydra`
+   kill 2 ${BH_PID}
    printf "\nBlue_Hydra process killed...\n"
    f_cleanup
 }
@@ -69,6 +70,6 @@ if loud_one=1 f_validate_one hci0; then
   trap f_endsummary INT
   trap f_endsummary KILL
   trap f_intbh SIGHUP
-  ./bin/blue_hydra
+  ./bin/blue_hydra 
   f_endsummary
 fi

--- a/scripts/blue_hydra.sh
+++ b/scripts/blue_hydra.sh
@@ -7,6 +7,19 @@ clear
 bluetooth=1
 . /opt/pwnix/pwnpad-scripts/px_functions.sh
 
+f_intbh(){
+bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
+`kill 2 ${bhPID}`
+printf "Blue_Hydra process killed..."
+f_cleanup
+}
+
+f_cleanup(){
+  printf "\nStopping Services..."
+  service dbus stop 
+  service bluetooth stop
+}
+
 f_endsummary() {
   clear
   printf "\n[-] Blue_Hydra db file saved to /opt/pwnix/data/blue_hydra/blue_hydra.db\n\n"
@@ -28,6 +41,7 @@ EOF
     printf "\n[-] Blue_Hydra summary saved to $FILENAME\n\n"
   fi
   cd /opt/pwnix/captures/bluetooth
+  f_cleanup
 }
 
 f_savecap() {
@@ -54,6 +68,7 @@ if loud_one=1 f_validate_one hci0; then
   cd /opt/pwnix/blue_hydra/
   trap f_endsummary INT
   trap f_endsummary KILL
+  trap f_intbh SIGHUP
   ./bin/blue_hydra
   f_endsummary
 fi

--- a/scripts/blue_hydra.sh
+++ b/scripts/blue_hydra.sh
@@ -8,15 +8,15 @@ bluetooth=1
 . /opt/pwnix/pwnpad-scripts/px_functions.sh
 
 f_intbh(){
-bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
-`kill 2 ${bhPID}`
-printf "Blue_Hydra process killed..."
-f_cleanup
+   bhPID=`ps aux |grep -m 1 -i blue_hydra|grep -v grep | awk {'print $2'}`
+   `kill 2 ${bhPID}`
+   printf "\nBlue_Hydra process killed...\n"
+   f_cleanup
 }
 
 f_cleanup(){
-  printf "\nStopping Services..."
-  service dbus stop 
+  printf "\nStopping Services...\n"
+  service dbus stop #needed?
   service bluetooth stop
 }
 

--- a/scripts/evilap.sh
+++ b/scripts/evilap.sh
@@ -184,8 +184,11 @@ f_karmaornot(){
   logname=$(f_logname)
   printf "[+] Creating new logfile: $logname\n"
 
-  trap f_endclean SIGINT SIGTERM EXIT
-
+  trap f_endclean SIGHUP
+  trap f_endclean SIGINT
+  trap f_endclean SIGTERM
+  trap f_endclean EXIT
+  
   #Start evilap
   if [ "${evilap_type}" = "airbase-ng" ]; then
     airbase-ng $airbase_flags -c $channel -e "$ssid" -v wlan1mon > "$logname" 2>&1 &

--- a/scripts/sslstrip.sh
+++ b/scripts/sslstrip.sh
@@ -44,6 +44,7 @@ f_run(){
   f_interface
   trap f_clean_up INT
   trap f_clean_up KILL
+  trap f_clean_up SIGHUP
 
   f_ip_tables
 


### PR DESCRIPTION
When the user closes the terminal emulator window without breaking the script with ctrl-c we need to clean up still.