### PR TITLE
this is likely a safer way to trap

### DIFF
--- a/scripts/evilap.sh
+++ b/scripts/evilap.sh
@@ -39,7 +39,7 @@ f_sanity_check(){
 f_endclean(){
   printf "\n[-] Exiting...\n"
   f_restore_ident
-  f_clean_up
+  [ "$EXIT_NOW" = 0 ] && f_clean_up
   EXIT_NOW=1
 }
 
@@ -193,6 +193,8 @@ f_karmaornot(){
   printf "[+] Creating new logfile: $logname\n"
 
   trap f_endclean EXIT
+  trap f_endclean INT
+  trap f_endclean TERM
 
   #Start evilap
   if [ "${evilap_type}" = "airbase-ng" ]; then


### PR DESCRIPTION
This should solve the reported issue but it NEEDS TESTED
https://github.com/pwnieexpress/pwn_pad_sources/issues/132

When we dropped trapping of sigint and sigterm it did not occur to me that trapping quit would only work for if the shell is quit, not the script.  Meaning according to the report ". ./evilap.sh" will trap properly on ^C but "./evilap.sh" won't.  I have not tested the reported issue, nor have I tested the fix.  But we removed the trap because it was double running cleanup and this prevents that.